### PR TITLE
Moving ESI out of database.py

### DIFF
--- a/server/admin.py
+++ b/server/admin.py
@@ -4,13 +4,11 @@ from database import User, Character
 async def get_users():
     return_list = []
     for user in User.query().run():
-        print('id', user.id, user.name)
-    for user in User.query().run():
         return_list.append({
-            'id': user.id,
+            'id': user.get_id(),
             'is_admin': user.is_admin,
             'is_recruiter': user.is_recruiter,
             'is_senior_recruiter': user.is_senior_recruiter,
-            'name': Character.get(user.id).name,
+            'name': Character.get(user.get_id()).name,
         })
     return {'info': return_list}

--- a/server/auth.py
+++ b/server/auth.py
@@ -15,7 +15,8 @@ import backoff
 
 login_manager = LoginManager()
 login_manager.init_app(app)
-login_manager.login_view = "/app/index.html"
+login_manager.login_view = "/auth/login"
+
 
 def ensure_has_access(user_id, target_user_id, self_access=False):
     if not has_access(user_id, target_user_id, self_access=self_access):
@@ -99,7 +100,7 @@ def api_oauth_callback():
     character = process_oauth(code)
     if login_type == 'login':
         print('char', character)
-        user = User.get(character.user_id, name=character.name)
+        user = User.get(character.user_id)
         login_user(user)
         if user.is_applicant:
             return redirect(f'{react_app_url}?showing=applicant')

--- a/server/character_data.py
+++ b/server/character_data.py
@@ -14,9 +14,10 @@ SECONDS_TO_CACHE = 10 * 60
 def get_character_calendar(character_id):
     # TODO: Need to return not just data from this endpoint, but also
     # the get_characters_character_id_calendar_event_id endpoint
-    calendar_data = get_op(
+    character = Character.get(character_id)
+    calendar_data = character.get_op(
         'get_characters_character_id_calendar',
-        auth_id=character_id, character_id=character_id
+        character_id=character_id
     )
     return {'info': calendar_data}
 
@@ -47,9 +48,10 @@ def get_transaction_party(party_id):
 
 @cachetools.cached(cachetools.TTLCache(maxsize=1000, ttl=SECONDS_TO_CACHE))
 def get_character_wallet(character_id):
-    wallet_data = get_paged_op(
+    character = Character.get(character_id)
+    wallet_data = character.get_paged_op(
         'get_characters_character_id_wallet_journal',
-        auth_id=character_id, character_id=character_id
+        character_id=character_id
     )
     for wallet_entry in wallet_data:
         redlisted = wallet_entry['amount'] == 0
@@ -68,9 +70,9 @@ def get_character_wallet(character_id):
 
 @cachetools.cached(cachetools.TTLCache(maxsize=1000, ttl=SECONDS_TO_CACHE))
 def get_character_contacts(character_id):
-    contacts_list = get_paged_op(
+    character = Character.get(character_id)
+    contacts_list = character.get_paged_op(
         'get_characters_character_id_contacts',
-        auth_id=character_id,
         character_id=character_id
     )
     contacts_dict = {entry['contact_id']: entry for entry in contacts_list}
@@ -91,9 +93,9 @@ def get_character_contacts(character_id):
 
 @cachetools.cached(cachetools.TTLCache(maxsize=1000, ttl=SECONDS_TO_CACHE))
 def get_character_mining(character_id):
-    mining_data = get_op(
+    character = Character.get(character_id)
+    mining_data = character.get_op(
         'get_characters_character_id_mining',
-        auth_id=character_id,
         character_id=character_id,
     )
     return_list = []
@@ -116,16 +118,15 @@ def get_character_mining(character_id):
 
 @cachetools.cached(cachetools.TTLCache(maxsize=1000, ttl=SECONDS_TO_CACHE))
 def get_character_market_contracts(character_id):
-    contract_list = get_paged_op(
+    character = Character.get(character_id)
+    contract_list = character.get_paged_op(
         'get_characters_character_id_contracts',
-        auth_id=character_id,
         character_id=character_id
     )
     # issuer_corporation, acceptor, issuer, end_location, start_location
     for entry in contract_list:
         entry['items'] = get_op(
             'get_characters_character_id_contracts_contract_id_items',
-            auth_id=character_id,
             character_id=character_id,
             contract_id=entry['contract_id'],
         )
@@ -156,9 +157,9 @@ def get_character_market_contracts(character_id):
 
 @cachetools.cached(cachetools.TTLCache(maxsize=1000, ttl=SECONDS_TO_CACHE))
 def get_character_assets(character_id):
-    asset_list = get_paged_op(
+    character = Character.get(character_id)
+    asset_list = character.get_paged_op(
         'get_characters_character_id_assets',
-        auth_id=character_id,
         character_id=character_id,
     )
     for entry in asset_list:
@@ -172,17 +173,16 @@ def get_character_assets(character_id):
 
 @cachetools.cached(cachetools.TTLCache(maxsize=1000, ttl=SECONDS_TO_CACHE))
 def get_character_bookmarks(character_id):
-    bookmarks_list = get_paged_op(
+    character = Character.get(character_id)
+    bookmarks_list = character.get_paged_op(
         'get_characters_character_id_bookmarks',
-        auth_id=character_id,
         character_id=character_id,
     )
     bookmarks_dict = {entry['bookmark_id']: entry for entry in bookmarks_list}
     for bookmark_id, entry in bookmarks_dict.items():
         if 'folder_id' in entry.keys():
-            entry['folder_name'] = get_op(
+            entry['folder_name'] = character.get_op(
                 'get_characters_character_id_bookmarks_folder',
-                auth_id=character_id,
                 character_id=character_id,
                 folder_id=entry['folder_id']
             )['name']
@@ -197,9 +197,9 @@ def get_character_bookmarks(character_id):
 
 @cachetools.cached(cachetools.TTLCache(maxsize=1000, ttl=SECONDS_TO_CACHE))
 def get_character_mail(character_id):
-    mail_list = get_paged_op(
+    character = Character.get(character_id)
+    mail_list = character.get_paged_op(
         'get_characters_character_id_mail',
-        auth_id=character_id,
         character_id=character_id,
     )
     mail_dict = {entry['mail_id']: entry for entry in mail_list}
@@ -215,9 +215,9 @@ def get_character_mail(character_id):
 
 @cachetools.cached(cachetools.LRUCache(maxsize=500))
 def get_mail_body(character_id, mail_id):
-    mail_data = get_op(
+    character = Character.get(character_id)
+    mail_data = character.get_op(
         'get_characters_character_id_mail_mail_id',
-        auth_id=character_id,
         character_id=character_id,
         mail_id=mail_id,
     )
@@ -226,14 +226,13 @@ def get_mail_body(character_id, mail_id):
 
 @cachetools.cached(cachetools.TTLCache(maxsize=1000, ttl=SECONDS_TO_CACHE))
 def get_character_market_history(character_id):
-    order_list = get_paged_op(
+    character = Character.get(character_id)
+    order_list = character.get_paged_op(
         'get_characters_character_id_orders',
-        auth_id=character_id,
         character_id=character_id,
     )
-    order_list.extend(get_paged_op(
+    order_list.extend(character.get_paged_op(
         'get_characters_character_id_orders_history',
-        auth_id=character_id,
         character_id=character_id,
     ))
     for order in order_list:
@@ -254,14 +253,13 @@ def get_character_market_history(character_id):
 
 @cachetools.cached(cachetools.TTLCache(maxsize=1000, ttl=SECONDS_TO_CACHE))
 def get_character_skills(character_id):
-    skill_data = get_op(
+    character = Character.get(character_id)
+    skill_data = character.get_op(
         'get_characters_character_id_skills',
-        auth_id=character_id,
         character_id=character_id,
     )
-    queue_data = get_op(
+    queue_data = character.get_op(
         'get_characters_character_id_skillqueue',
-        auth_id=character_id,
         character_id=character_id,
     )
     for skill_list in skill_data, queue_data:

--- a/server/database.py
+++ b/server/database.py
@@ -1,12 +1,8 @@
 from anom import props, set_adapter, Key, Model
 from anom.adapters import DatastoreAdapter, MemcacheAdapter
-import os
 import pylibmc
-from esipy import EsiClient, EsiSecurity
-from esipy.cache import DictCache
-from pyswagger import App
-from esi_config import client_id, secret_key, callback_url, client_name
 from flask_login import UserMixin
+from esi import get_op, get_paged_op
 
 
 memcache_client = pylibmc.Client(
@@ -100,7 +96,6 @@ class Group(AsceeModel):
         return group
 
 
-
 class TypePrice(AsceeModel):
     price = props.Float(default=0.)
 
@@ -114,7 +109,6 @@ class TypePrice(AsceeModel):
             )
             type_price.put()
         return type_price
-
 
 
 class Region(AsceeModel):
@@ -325,7 +319,7 @@ class Character(AsceeModel):
     name = props.String()
     corporation_id = props.Integer(indexed=True)
     is_male = props.Bool()
-    refresh_token = props.String(optional=True)
+    refresh_token = props.Text(optional=True)
     redlisted = props.Bool(default=False)
 
     @classmethod
@@ -346,91 +340,14 @@ class Character(AsceeModel):
             character.put()
         return character
 
+    def get_op(self, op_name, **kwargs):
+        return get_op(op_name, refresh_token=self.refresh_token, **kwargs)
+
+    def get_paged_op(self, op_name, **kwargs):
+        return get_paged_op(op_name, refresh_token=self.refresh_token, **kwargs)
+
     def is_redlisted(self):
         if self.redlisted:
             return True
         else:
             return Corporation.get(self.corporation_id).is_redlisted
-
-#  Cache in a file because it takes a while to load
-current_dir = os.path.dirname(os.path.abspath(__file__))
-app_data_filename = os.path.join(current_dir, 'esi_app.pkl')
-
-# if os.path.isfile(app_data_filename):
-esi_app = App.create('https://esi.evetech.net/latest/swagger.json')
-    # pickle.dump(esi_app, open(app_data_filename, 'wb'))
-# else:
-#     esi_app = pickle.load(open(app_data_filename, 'rb'))
-
-client_dict = {}
-
-
-def get_esi_client(auth_id=None):
-    if auth_id not in client_dict:
-        client_dict[auth_id] = initialize_esi_client(auth_id)
-    return client_dict[auth_id]
-
-
-def initialize_esi_client(auth_id=None):
-    """
-    Retrieves a public or authorized ESI client.
-
-    Args:
-        auth_id (optional): character_id of the user whose client we want to
-            retrieve. By default, a public ESI client is returned.
-
-    Returns:
-        esi_client (EsiClient): Client object from esipy.
-    """
-    auth = EsiSecurity(
-        headers={'User-Agent': client_name},
-        redirect_uri='https://localhost/callback',
-        client_id=client_id,
-        secret_key=secret_key,
-    )
-    if auth_id is not None:
-        auth.refresh_token = Character.get(auth_id).refresh_token
-    esi_client = EsiClient(
-        auth,
-        retry_requests=True,
-        cache=DictCache(),
-        headers={'User-Agent': client_name},
-    )
-    return esi_client
-
-
-class ESIError(Exception):
-    pass
-
-
-def get_op(op_name, auth_id=None, **kwargs):
-    esiClient = get_esi_client(auth_id)
-    response = esiClient.request(esi_app.op[op_name](**kwargs))
-    if isinstance(response, dict) and 'error' in response.keys():
-        raise ESIError(response['error'])
-    else:
-        return response.data
-
-
-def get_paged_op(op_name, auth_id=None, **kwargs):
-    esi_client = get_esi_client(auth_id)
-    response = esi_client.request(esi_app.op[op_name](page=1, **kwargs))
-    return_list = []
-    return_list.extend(response.data)
-    try:
-        assert len(response.header['X-Pages']) == 1
-        pages = int(response.header['X-Pages'][0])
-    except KeyError:
-        print('No page numbers given in getPagedOp, request {}, {}'.format(op_name, kwargs))
-        print('Response: {}'.format(response))
-        return []
-
-    operations = [
-        esi_app.op[op_name](page=page, **kwargs) for page in range(2, pages+1)
-    ]
-
-    result_list = []
-    for request, response in esi_client.multi_request(operations):
-        result_list.extend(response.data)
-
-    return return_list

--- a/server/esi.py
+++ b/server/esi.py
@@ -1,1 +1,88 @@
-from database import get_op, get_paged_op
+import backoff
+import urllib
+from esipy import EsiClient, EsiSecurity
+from esipy.cache import DictCache
+from pyswagger import App
+from esi_config import client_id, secret_key, callback_url, client_name
+
+
+@backoff.on_exception(
+    backoff.expo, urllib.error.HTTPError, max_time=10,
+)
+def get_esi_app():
+    return App.create('https://esi.evetech.net/latest/swagger.json')
+
+esi_app = get_esi_app()
+
+client_dict = {}
+
+
+def get_esi_client(refresh_token=None):
+    if refresh_token not in client_dict:
+        client_dict[refresh_token] = initialize_esi_client(refresh_token)
+    return client_dict[refresh_token]
+
+
+def initialize_esi_client(refresh_token=None):
+    """
+    Retrieves a public or authorized ESI client.
+
+    Args:
+        auth_id (optional): refresh_token of the user whose client we want to
+            retrieve. By default, a public ESI client is returned.
+
+    Returns:
+        esi_client (EsiClient): Client object from esipy.
+    """
+    auth = EsiSecurity(
+        headers={'User-Agent': client_name},
+        redirect_uri='https://localhost/callback',
+        client_id=client_id,
+        secret_key=secret_key,
+    )
+    if refresh_token is not None:
+        auth.refresh_token = refresh_token
+    esi_client = EsiClient(
+        auth,
+        retry_requests=True,
+        cache=DictCache(),
+        headers={'User-Agent': client_name},
+    )
+    return esi_client
+
+
+class ESIError(Exception):
+    pass
+
+
+def get_op(op_name, refresh_token=None, **kwargs):
+    esiClient = get_esi_client(refresh_token)
+    response = esiClient.request(esi_app.op[op_name](**kwargs))
+    if isinstance(response, dict) and 'error' in response.keys():
+        raise ESIError(response['error'])
+    else:
+        return response.data
+
+
+def get_paged_op(op_name, refresh_token=None, **kwargs):
+    esi_client = get_esi_client(refresh_token)
+    response = esi_client.request(esi_app.op[op_name](page=1, **kwargs))
+    return_list = []
+    return_list.extend(response.data)
+    try:
+        assert len(response.header['X-Pages']) == 1
+        pages = int(response.header['X-Pages'][0])
+    except KeyError:
+        print('No page numbers given in getPagedOp, request {}, {}'.format(op_name, kwargs))
+        print('Response: {}'.format(response))
+        return []
+
+    operations = [
+        esi_app.op[op_name](page=page, **kwargs) for page in range(2, pages+1)
+    ]
+
+    result_list = []
+    for request, response in esi_client.multi_request(operations):
+        result_list.extend(response.data)
+
+    return return_list

--- a/server/main.py
+++ b/server/main.py
@@ -564,3 +564,6 @@ def api_server_error(e):
     logging.exception('An error occurred during a request.')
     return 'An internal error occurred.', 500
 # [END app]
+
+if __name__ == '__main__':
+    app.run()

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,3 +4,7 @@ cachetools==3.0.0
 anom[memcache]==0.8.0
 flask_login==0.4.1
 backoff==1.8.0
+google-api-python-client
+vcrpy-unittest
+mock
+contextlib2


### PR DESCRIPTION
On the road to unit tests, I've done a refactor to move ESI operations out of database.py. Auth'd ESI operations are now done using Character.get_op and Character.get_paged_op. This avoids the ESI code needing to access Character to get refresh tokens - instead, Character sends its refresh token to get_op or get_paged_op.

I propagated the refactor to everywhere that get_op was called.